### PR TITLE
Feature: Add option for collapsedHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const {
   defaultOpen: boolean,
   expandStyles: {},
   collapseStyles: {},
+  collapsedHeight: 0
 });
 ```
 
@@ -94,6 +95,7 @@ The following are optional properties passed into `useCollapse({ })`:
 | defaultOpen    | boolean | `false`                                                                                              | If true, the Collapse will be expanded when mounted          |
 | expandStyles   | object  | `{transitionDuration: '500ms' transitionTimingFunction: 'cubic-bezier(0.250, 0.460, 0.450, 0.940)'}` | Style object applied to the collapse panel when it expands   |
 | collapseStyles | object  | `{transitionDuration: '500ms' transitionTimingFunction: 'cubic-bezier(0.250, 0.460, 0.450, 0.940)'}` | Style object applied to the collapse panel when it collapses |
+| collapsedHeight| number  | `0`                                                                                                ` | The  height of the content when collapsed                    |
 
 ### What you get
 

--- a/src/react-collapsed.js
+++ b/src/react-collapsed.js
@@ -16,12 +16,13 @@ export default function useCollapse(initialConfig = {}) {
   const [isOpen, setOpen] = useStateOrProps(initialConfig);
   const [shouldAnimateOpen, setShouldAnimateOpen] = useState(null);
   const [heightAtTransition, setHeightAtTransition] = useState(0);
+  const collapsedHeight = `${initialConfig.collapsedHeight || 0}px`;
   const {expandStyles, collapseStyles} = useMemo(
     () => makeTransitionStyles(initialConfig),
     [initialConfig]
   );
   const [styles, setStyles] = useState(
-    isOpen ? null : {display: 'none', height: '0px'}
+    isOpen ? null : {display: collapsedHeight === '0px' ? 'none' : 'block', height: collapsedHeight, overflow: 'hidden'}
   );
   const [mountChildren, setMountChildren] = useState(isOpen);
 
@@ -55,7 +56,7 @@ export default function useCollapse(initialConfig = {}) {
       raf(() => {
         setStyles(oldStyles => ({
           ...oldStyles,
-          height: '0px',
+          height: collapsedHeight,
           overflow: 'hidden',
         }));
         setHeightAtTransition(height);
@@ -83,8 +84,9 @@ export default function useCollapse(initialConfig = {}) {
     } else {
       setMountChildren(false);
       setStyles({
-        display: 'none',
-        height: '0px',
+        overflow: 'hidden',
+        display: collapsedHeight === '0px' ? 'none' : 'block',
+        height: collapsedHeight,
       });
     }
   };


### PR DESCRIPTION
This adds an option to set the height of the content div after you collapsed it.
Without this option the content collapses to `0px` and is set to `display: none`.

With this option you can show part of the content and expose all of it by clicking the expand button.

![ezgif com-optimize](https://user-images.githubusercontent.com/1710840/59831082-56354600-9341-11e9-8fc1-d35bae6658cb.gif)