### PR TITLE
Feature: hide toggle button when content is fully visible

### DIFF
--- a/src/react-collapsed.js
+++ b/src/react-collapsed.js
@@ -1,4 +1,3 @@
-/* tslint:disable */
 import {useState, useRef, useCallback, useMemo} from 'react';
 import raf from 'raf';
 import {
@@ -113,7 +112,6 @@ export default function useCollapse(initialConfig = {}) {
         onClick: noop,
       }
     ) {
-    	console.log(displayToggleButtonStyles(el.current));
       return {
         type: 'button',
         role: 'button',
@@ -129,26 +127,25 @@ export default function useCollapse(initialConfig = {}) {
     getCollapseProps(
       {style, onTransitionEnd, ...rest} = {style: {}, onTransitionEnd: noop}
     ) {
-    	const contentStyles = {
-				// Default transition duration and timing function, so height will transition
-				// when resting and the height of the collapse changes
-				...defaultTransitionStyles,
-				// additional styles passed, e.g. getCollapseProps({style: {}})
-				...style,
-				// combine any additional transition properties with height
-				transitionProperty: joinTransitionProperties(
-					style.transitionProperty
-				),
-				// style overrides from state
-				...styles,
-			};
       return {
         id: `react-collapsed-panel-${uniqueId}`,
         'aria-hidden': isOpen ? null : 'true',
         ...rest,
         ref: el,
         onTransitionEnd: callAll(handleTransitionEnd, onTransitionEnd),
-        style: contentStyles,
+        style: {
+					// Default transition duration and timing function, so height will transition
+					// when resting and the height of the collapse changes
+					...defaultTransitionStyles,
+					// additional styles passed, e.g. getCollapseProps({style: {}})
+					...style,
+					// combine any additional transition properties with height
+					transitionProperty: joinTransitionProperties(
+						style.transitionProperty
+					),
+					// style overrides from state
+					...styles,
+				},
       };
     },
     isOpen,

--- a/src/react-collapsed.js
+++ b/src/react-collapsed.js
@@ -21,8 +21,8 @@ export default function useCollapse(initialConfig = {}) {
     [initialConfig]
   );
   const getCollapsedHeightStyle = () => {
-  	return initialConfig.collapsedHeight + 'px';
-	};
+    return initialConfig.collapsedHeight + 'px';
+  };
   const [styles, setStyles] = useState(
     isOpen ? null : {display: getCollapsedHeightStyle() === '0px' ? 'none' : 'block', height: getCollapsedHeightStyle(), overflow: 'hidden'}
   );
@@ -86,7 +86,7 @@ export default function useCollapse(initialConfig = {}) {
     } else {
       setMountChildren(false);
       setStyles({
-				overflow: 'hidden',
+        overflow: 'hidden',
         display: getCollapsedHeightStyle() === '0px' ? 'none' : 'block',
         height: getCollapsedHeightStyle(),
       });
@@ -94,16 +94,16 @@ export default function useCollapse(initialConfig = {}) {
   };
 
   const displayToggleButtonStyles = (el) => {
-		if (el) {
-			const contentFitsInsideContainer = el.children[0].getBoundingClientRect().height < el.getBoundingClientRect().height;
-			if (contentFitsInsideContainer) {
-				return {display: 'none'};
-			}
-			return {};
-		} else {
-			return {};
-		}
-	};
+    if (el) {
+      const contentFitsInsideContainer = el.children[0].getBoundingClientRect().height < el.getBoundingClientRect().height;
+      if (contentFitsInsideContainer) {
+        return {display: 'none'};
+      }
+      return {};
+    } else {
+      return {};
+    }
+  };
 
   return {
     getToggleProps(
@@ -119,7 +119,7 @@ export default function useCollapse(initialConfig = {}) {
         'aria-controls': `react-collapsed-panel-${uniqueId}`,
         'aria-expanded': isOpen ? 'true' : 'false',
         tabIndex: 0,
-				style: displayToggleButtonStyles(el.current),
+        style: displayToggleButtonStyles(el.current),
         ...rest,
         onClick: disabled ? noop : callAll(onClick, toggleOpen),
       };
@@ -134,18 +134,18 @@ export default function useCollapse(initialConfig = {}) {
         ref: el,
         onTransitionEnd: callAll(handleTransitionEnd, onTransitionEnd),
         style: {
-					// Default transition duration and timing function, so height will transition
-					// when resting and the height of the collapse changes
-					...defaultTransitionStyles,
-					// additional styles passed, e.g. getCollapseProps({style: {}})
-					...style,
-					// combine any additional transition properties with height
-					transitionProperty: joinTransitionProperties(
-						style.transitionProperty
-					),
-					// style overrides from state
-					...styles,
-				},
+          // Default transition duration and timing function, so height will transition
+          // when resting and the height of the collapse changes
+          ...defaultTransitionStyles,
+          // additional styles passed, e.g. getCollapseProps({style: {}})
+          ...style,
+          // combine any additional transition properties with height
+          transitionProperty: joinTransitionProperties(
+            style.transitionProperty
+          ),
+          // style overrides from state
+          ...styles,
+        },
       };
     },
     isOpen,


### PR DESCRIPTION
When using the collaspedHeight option, the toggle button should hide if the content is fully visible.

I also changed some code to make sure the styles correctly rerendered when the collapsedHeight is changed by the parent component.