### PR TITLE
Fix mismatch of useIsomorphicLayoutEffect logic

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,7 +138,7 @@ export function useEffectAfterMount(
  * @see Docs https://reach.tech/auto-id
  */
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? useEffect : useLayoutEffect;
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 let serverHandoffComplete = false;
 let id = 0;
 const genId = () => ++id;


### PR DESCRIPTION
After react-collapsed update we get warning in Next.js log:
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

The reason in broken condition result