### PR TITLE
Fix for hook depends

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ export default function useCollapse({
         })
       })
     }
-  }, [isExpanded])
+  }, [isExpanded, collapsedHeight])
 
   const handleTransitionEnd = (e: TransitionEvent): void => {
     // Sometimes onTransitionEnd is triggered by another transition,


### PR DESCRIPTION
Hello everyone!) Maybe I did something stupid and there will be some side effects.
But if you add collapsedHeight depending, when props collapsedHeight changes, there will be a normal reaction
But if not, we will not change its height, props can change