### PR TITLE
feat: Remove raf dependency (fixes #102)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@testing-library/react": "^13.4.0",
     "@types/jest": "^25.1.2",
     "@types/node": "^16.7.13",
-    "@types/raf": "^3.4.0",
     "@types/react": "^18.0.18",
     "@types/react-dom": "^18.0.6",
     "@types/styled-components": "^5.0.1",
@@ -72,7 +71,6 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "raf": "^3.4.1",
     "tiny-warning": "^1.0.3"
   },
   "jest": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { useState, useRef, TransitionEvent, CSSProperties } from 'react'
 import { flushSync } from 'react-dom'
-import raf from 'raf'
 import {
   noop,
   callAll,
@@ -77,7 +76,7 @@ export default function useCollapse({
 
   useEffectAfterMount(() => {
     if (isExpanded) {
-      raf(() => {
+      requestAnimationFrame(() => {
         onExpandStart()
         mergeStyles({
           ...expandStyles,
@@ -85,7 +84,7 @@ export default function useCollapse({
           display: 'block',
           overflow: 'hidden',
         })
-        raf(() => {
+        requestAnimationFrame(() => {
           const height = getElementHeight(el)
           mergeStyles({
             ...getTransitionStyles(height),
@@ -94,7 +93,7 @@ export default function useCollapse({
         })
       })
     } else {
-      raf(() => {
+      requestAnimationFrame(() => {
         onCollapseStart()
         const height = getElementHeight(el)
         mergeStyles({
@@ -103,7 +102,7 @@ export default function useCollapse({
           willChange: 'height',
           height,
         })
-        raf(() => {
+        requestAnimationFrame(() => {
           mergeStyles({
             height: collapsedHeight,
             overflow: 'hidden',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3312,11 +3312,6 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/raf@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@types/raf/-/raf-3.4.0.tgz#2b72cbd55405e071f1c4d29992638e022b20acc2"
-  integrity sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==
-
 "@types/react-dom@^18.0.0", "@types/react-dom@^18.0.6":
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
@@ -13047,13 +13042,6 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
-
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
 
 ramda@^0.21.0:
   version "0.21.0"


### PR DESCRIPTION
As @gaearon pointed out in the issue, React requires a requestAnimationFrame polyfill since version 16.